### PR TITLE
support OPENAI_COMPATIBLE_MODEL env var for OpenAI-compatible providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ DEEPSEEK_API_BASE=https://api.deepseek.com/v1
 # Custom OpenAI-compatible API
 OPENAI_COMPATIBLE_API_KEY=your_api_key_here
 OPENAI_COMPATIBLE_API_BASE=https://api.openai.com/v1
+# Optional: If your OpenAI-compatible provider does not support listing available models,
+# you can set a single model ID to use. When present, the app will return this model
+# instead of calling the remote API to list models.
+OPENAI_COMPATIBLE_MODEL=your_model_id_here
 # Other possible services for the custom API:
 # OPENAI_COMPATIBLE_API_BASE=https://api.together.xyz/v1    # Together AI
 # OPENAI_COMPATIBLE_API_BASE=https://api.groq.com/openai/v1 # Groq

--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ You can use any OpenAI-compatible API:
    OPENAI_COMPATIBLE_API_BASE=https://api.of.provider.com/v1
    ```
 
+If your OpenAI-compatible provider does not support listing available models (some third-party or self-hosted providers), you can explicitly set a single model ID to use with the `OPENAI_COMPATIBLE_MODEL` environment variable. When set, the app will return this model instead of attempting to call the provider's models.list endpoint.
+
+Example `.env.local`:
+```
+OPENAI_COMPATIBLE_API_KEY=your_api_key
+OPENAI_COMPATIBLE_API_BASE=https://api.of.provider.com/v1
+OPENAI_COMPATIBLE_MODEL=gpt-4o-mini
+```
+
 ## Deployment
 
 ### Deploying on Vercel

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -40,6 +40,15 @@ class OpenAICompatibleProvider implements LLMProviderClient {
   }
 
   async getModels() {
+    // If using the OPENAI_COMPATIBLE provider and an explicit model is set via
+    // the OPENAI_COMPATIBLE_MODEL environment variable, return that model
+    // instead of attempting to list models from the remote service (some
+    // third-party OpenAI-compatible providers do not support listing models).
+    const envModel = process.env.OPENAI_COMPATIBLE_MODEL;
+    if (this.provider === LLMProvider.OPENAI_COMPATIBLE && envModel) {
+      return [{ id: envModel, name: envModel }];
+    }
+    
     const response = await this.client.models.list();
 
     // Remove duplicates based on model ID


### PR DESCRIPTION
Add support for an environment variable (OPENAI_COMPATIBLE_MODEL) that, when set, makes OpenAI-compatible providers return that single model from getModels instead of attempting to list models from the remote service.

What I changed
- `provider.ts`
  - OpenAICompatibleProvider.getModels now returns [{ id, name }] from process.env.OPENAI_COMPATIBLE_MODEL if set; otherwise falls back to client.models.list().
- `.env.example`
  - Added OPENAI_COMPATIBLE_MODEL entry with placeholder.
- `README.md`
  - Documented the new OPENAI_COMPATIBLE_MODEL env variable and its behavior, plus an example usage note.

Why
Some third-party OpenAI-compatible providers don't support model listing. This provides an explicit opt-in so users can specify a model to use without network errors.

Migration / Notes
- To use this behavior, set `OPENAI_COMPATIBLE_MODEL=<model_id>` in your environment (.env.local or CI).
- If unset, the app will continue to call `client.models.list()` as before.
- Only `OpenAICompatibleProvider` is affected by this change.